### PR TITLE
Authenticate fn

### DIFF
--- a/src/RJMetrics/Client.php
+++ b/src/RJMetrics/Client.php
@@ -60,10 +60,8 @@ class Client {
 	 * @return boolean
 	 */
 	public function authenticate() {
-		$testData = json_decode("[{\"keys\":[\"id\"],\"id\":1}]");
-
 		try {
-			$this->pushData("test", $testData, self::SANDBOX_BASE);
+			$this->makeAuthenticateAPICall(self::API_BASE);
 		} catch(InvalidRequestException $e) {
 			return false;
 		}
@@ -137,6 +135,29 @@ class Client {
 		return $response;
 	}
 
+	/**
+	 * Client::makeAuthenticateAPICall
+	 *
+	 * Internal function to authorize with API.
+	 *
+	 * @param :optional string $url
+	 * @return object
+	 */
+	public function makeAuthenticateAPICall($url = self::API_BASE) {
+		$requestUrl = "{$url}/client/{$this->clientId}/authenticate?apikey={$this->apiKey}";
+
+		$response = \Httpful\Request::get($requestUrl)
+			->mime("application/json")
+			->timeout($this->timeoutInSeconds)
+			->send();
+
+		if($response->hasErrors())
+			throw new InvalidRequestException(
+				"The Import API returned: {$response->code} {$response->body->message}. ".
+				"Reasons: ".implode($response->body->reasons, ","));
+
+		return $response;
+	}
 
 }
 


### PR DESCRIPTION
### Motivation

We added the authenticate endpoint to the IAPI, let's use it.   That way the sandbox machine will no longer be production critical.
### API changes

None
### Implementation Notes

The endpoint is called authenticate.  Meaning the apikey provided exists, and matches the client-id in the url.  Implicitly, a 200 response means the apikey has at least REGULAR permissions, meaning the key can push data.  That's an authorization concern, but still a good question to answer.  
### Functional Tests

Made a php test script to test success and failure cases.  Success would return true.  Failure would throw an UnableToConnectionException.
### Regression Tests
### Screenshots
